### PR TITLE
link to contact page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,7 +9,7 @@
     <p>Try…</p>
     <p>…to start over on the <a href="{{ .Site.Home.RelPermalink }}">home page</a></p>
     <p>…to <a href="/search">search</a></p>
-    <p>If you cannot find it, <a href="/contact">ask us about it</a>. </p>
+    <p>If you cannot find it, <a href="https://carpentries.org/about-us/contact/">ask us about it</a>. </p>
   </div>
 </div>
 {{ end }}


### PR DESCRIPTION
As the 404 layout is being used on all our websites, the relative link to `/contact` does not work.  This PR adds the full URL to The Carpentries contact page.