### PR TITLE
change deprecated postcss

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -1,13 +1,13 @@
 {{/* styles */}}
 {{ $options := dict "inlineImports" true }}
 {{ $styles := resources.Get "css/styles.css" }}
-{{ $styles = $styles | resources.PostCSS $options }}
+{{ $styles = $styles | css.PostCSS $options }}
 {{ if not hugo.IsServer }}
   {{ $styles = $styles | minify | fingerprint | resources.PostProcess }}
 {{ end }}
 {{ with resources.Get "/icons/arrow-right-white.svg" }}
   {{ .Publish }}
-{{ end }}
+{{ end }} 
 {{ with resources.Match "/images/blob-*" }}
   {{ range . }}
     {{ .Publish }}


### PR DESCRIPTION
Based on error in build:

```
ERROR deprecated: resources.PostCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use css.PostCSS instead.

```