### PR TITLE
formatting of committee chair titles

### DIFF
--- a/layouts/shortcodes/committees.html
+++ b/layouts/shortcodes/committees.html
@@ -21,7 +21,7 @@
     <strong>{{ .committee_name }}</strong>
     <ul>
       {{ with .chair }}
-      <li><strong>Chair: </strong>{{ . }}</li>
+      <li>{{ . }} (Chair)</li>
       {{ end }}
       {{ with .members }}
         {{ range . }}


### PR DESCRIPTION
Addresses final point in https://github.com/carpentries/carpentries.org/issues/193 by formatting how we designate governance committee chairs.