### PR TITLE
rm default display of last-edited widget in sidebar

### DIFF
--- a/layouts/_default/sidebar.html
+++ b/layouts/_default/sidebar.html
@@ -11,7 +11,5 @@
   {{ end }}
   {{ partial "widgets/feedback" . }}
 
-  {{ partial "widgets/meta" . }}
-
   {{ partial "widgets/edit-github" . }}
 </div>


### PR DESCRIPTION
Addresses #58 by removing the "last-edited" widget default display on the page sidebar.  
Note this will require adding it back in on each page of each site we want it to display.