### PR TITLE
lowercase tags & authors in blog list titles

### DIFF
--- a/layouts/partials/widgets/blog-links.html
+++ b/layouts/partials/widgets/blog-links.html
@@ -1,5 +1,5 @@
 <ul class="text-sm font-bold">
-  <li class="mb-2"><a class="underline" href="/blog/posts-by-tags/">Posts by Tag</a></li>
-  <li><a class="underline" href="/blog/posts-by-authors/">Posts by Author</a></li>
+  <li class="mb-2"><a class="underline" href="/blog/posts-by-tags/">Posts by tag</a></li>
+  <li><a class="underline" href="/blog/posts-by-authors/">Posts by author</a></li>
 </ul>
 <hr class="my-8">


### PR DESCRIPTION
Addresses point in #https://github.com/carpentries/carpentries.org/issues/195 by making "Posts by author" and "Posts by tag" lowercase. 