### PR TITLE
prevent quotation marks around blockquote text

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -182,3 +182,14 @@ ul.badges li:before{
 .pagination li.active {
   @apply font-bold;
 }
+
+/* Prevents quotation marks from being added in block quotes */
+
+blockquote {
+  quotes: none !important;
+}
+
+blockquote p::before,
+blockquote p::after {
+  content: none !important;
+}


### PR DESCRIPTION
External css was injecting quotation marks inside blockquotes resulting in something like this:

<img width="626" height="138" alt="image" src="https://github.com/user-attachments/assets/49c9830b-30c6-48c8-86a8-7bc3ecd9d956" />

This adds css override to not insert quotation marks. Quotation marks can still be included in the source text if desired.